### PR TITLE
Fetch weekly average prices

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,7 +17,7 @@ from strompris import (
     fetch_day_prices,
     fetch_prices,
     plot_activity_prices,
-    plot_prices,
+    plot_prices, fetch_weekly_average_prices,
 )
 
 app = FastAPI(title="FastAPI Strompris",
@@ -106,6 +106,21 @@ async def get_plot(location: str = "NO1", activity : str = "shower", minutes: in
     df = fetch_day_prices(datetime.date.today(), location)
     chart = plot_activity_prices(df, activity, minutes)
     return chart.to_dict()
+
+
+@app.get("/weekly_average_prices")
+async def get_weekly_average_prices(location: str = Query("NO1", enum=list(LOCATION_CODES.keys()))):
+    """
+    Endpoint to get weekly average electricity prices for a specified location.
+    Args:
+        location (str): Location to get the prices for. Defaults to "NO1".
+
+    Returns:
+        dict: A dictionary containing the average prices for the past week.
+    """
+    weekly_avg_df = fetch_weekly_average_prices(location=location)
+    return weekly_avg_df.to_dict(orient='records')
+
 
 # mount your docs directory as static files at `/help`
 

--- a/strompris.py
+++ b/strompris.py
@@ -49,6 +49,27 @@ def fetch_day_prices(date: datetime.date = None, location: str = "NO1") -> pd.Da
     return df
 
 
+def fetch_weekly_average_prices(location: str = 'NO1') -> pd.DataFrame:
+    """
+    Fetches and calculates the average electricity prices for the past week for a specific location.
+
+    Args:
+        location (str): The location code for which to fetch average prices.
+
+    Returns:
+        pd.DataFrame: A dataframe containing the average prices for each day of the past week.
+    """
+    end_date = datetime.date.today()
+    start_date = end_date - datetime.timedelta(days=7)
+    dfs = []
+    for single_date in (start_date + datetime.timedelta(n) for n in range(7)):
+        daily_df = fetch_day_prices(date=single_date, location=location)
+        daily_avg_price = {'date': single_date, 'average_price': daily_df['NOK_per_kWh'].mean()}
+        dfs.append(pd.DataFrame([daily_avg_price]))
+    weekly_avg_df = pd.concat(dfs)
+    return weekly_avg_df
+
+
 # LOCATION_CODES maps codes ("NO1") to names ("Oslo")
 LOCATION_CODES = {
     "NO1": "Oslo",


### PR DESCRIPTION
This pull request introduces improvements to the `app.py` and `strompris.py` files. The changes primarily focus on adding a new feature to fetch and calculate the average electricity prices for the past week for a specific location. The most important changes include the addition of a new function `fetch_weekly_average_prices`, a new endpoint `get_weekly_average_prices`, and an update to the import list in `app.py`.

Addition of new features:

* [`strompris.py`](diffhunk://#diff-4f943bf06b5ebd0f7108180f70350aef11643e1f7d1464cac22bc4c0962638dfR52-R72): Added a new function `fetch_weekly_average_prices` that fetches and calculates the average electricity prices for the past week for a specific location. This function uses a loop to fetch the daily prices, calculates the daily average, and then combines the data into a weekly average dataframe.

* [`app.py`](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R110-R124): Added a new endpoint `get_weekly_average_prices` that uses the `fetch_weekly_average_prices` function to return a dictionary containing the average prices for the past week for a specified location.

Updates to existing code:

* [`app.py`](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L20-R20): Updated the import list to include the new function `fetch_weekly_average_prices`.